### PR TITLE
Remove Python 2.7, add 3.7, support conda deploy in forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,14 @@ language: generic
 matrix:
   include:
     - os: linux
-      env: PYTHON=2.7
+      env: PYTHON=3.6
     - os: linux
-      env: PYTHON=3.6
-    - os: osx
-      env: PYTHON=2.7
-      osx_image: xcode10.1
+      env: PYTHON=3.7
     - os: osx
       env: PYTHON=3.6
       osx_image: xcode10.1
-  allow_failures:
     - os: osx
-      env: PYTHON=2.7
+      env: PYTHON=3.7
       osx_image: xcode10.1
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,11 +50,11 @@ script:
 deploy:
   - provider: script
     skip_cleanup: true
-    script: anaconda -t $CONDA_UPLOAD_TOKEN upload --user ome $HOME/miniconda/conda-bld/$TRAVIS_OS_NAME-64/$PACKAGE_NAME-*.tar.bz2 --force -l testing
+    script: anaconda -t "$CONDA_UPLOAD_TOKEN" upload --user ${TRAVIS_REPO_SLUG%/*} $HOME/miniconda/conda-bld/$TRAVIS_OS_NAME-64/$PACKAGE_NAME-*.tar.bz2 --force -l testing
     on:
       branch: master
   - provider: script
     skip_cleanup: true
-    script: anaconda -t $CONDA_UPLOAD_TOKEN upload --user ome $HOME/miniconda/conda-bld/$TRAVIS_OS_NAME-64/$PACKAGE_NAME-*.tar.bz2
+    script: anaconda -t "$CONDA_UPLOAD_TOKEN" upload --user ${TRAVIS_REPO_SLUG%/*} $HOME/miniconda/conda-bld/$TRAVIS_OS_NAME-64/$PACKAGE_NAME-*.tar.bz2
     on:
       tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
 env:
   global:
     - PACKAGE_NAME=zeroc-ice36-python
+    - ANACONDA_USER=${TRAVIS_REPO_SLUG%/*}
     - PATH="$HOME/miniconda/bin:$PATH"
 
 install:
@@ -50,11 +51,11 @@ script:
 deploy:
   - provider: script
     skip_cleanup: true
-    script: anaconda -t "$CONDA_UPLOAD_TOKEN" upload --user ${TRAVIS_REPO_SLUG%/*} $HOME/miniconda/conda-bld/$TRAVIS_OS_NAME-64/$PACKAGE_NAME-*.tar.bz2 --force -l testing
+    script: anaconda -t "$CONDA_UPLOAD_TOKEN" upload --user ${ANACONDA_USER} $HOME/miniconda/conda-bld/$TRAVIS_OS_NAME-64/$PACKAGE_NAME-*.tar.bz2 --force -l testing
     on:
       branch: master
   - provider: script
     skip_cleanup: true
-    script: anaconda -t "$CONDA_UPLOAD_TOKEN" upload --user ${TRAVIS_REPO_SLUG%/*} $HOME/miniconda/conda-bld/$TRAVIS_OS_NAME-64/$PACKAGE_NAME-*.tar.bz2
+    script: anaconda -t "$CONDA_UPLOAD_TOKEN" upload --user ${ANACONDA_USER} $HOME/miniconda/conda-bld/$TRAVIS_OS_NAME-64/$PACKAGE_NAME-*.tar.bz2
     on:
       tags: true

--- a/meta.yaml
+++ b/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 4235ffeb605bcd4e22e716577f7d61e4aa1bc82f65276bb542701a81b7933356
 
 build:
-  number: 2
+  number: 3
   entry_points:
     - slice2py=slice2py:main
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "


### PR DESCRIPTION
Suggested tag: `3.6.5-3`

Can be tested with
- `conda install -c manics python=3.6 zeroc-ice36-python`
- `conda install -c manics python=3.7 zeroc-ice36-python`