### PR TITLE
Win64 support: Azure pipeline for all releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,9 +48,10 @@ script:
     fi
   - conda build --python $PYTHON .
 
-deploy:
-  - provider: script
-    skip_cleanup: true
-    script: anaconda -t "$CONDA_UPLOAD_TOKEN" upload --user ${ANACONDA_USER} $HOME/miniconda/conda-bld/$TRAVIS_OS_NAME-64/$PACKAGE_NAME-*.tar.bz2
-    on:
-      tags: true
+# Deployment has switched to Azure Pipelines (Linux, OSX, Win64)
+# deploy:
+#   - provider: script
+#     skip_cleanup: true
+#     script: anaconda -t "$CONDA_UPLOAD_TOKEN" upload --user ${ANACONDA_USER} $HOME/miniconda/conda-bld/$TRAVIS_OS_NAME-64/$PACKAGE_NAME-*.tar.bz2
+#     on:
+#       tags: true

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Conda package for Zeroc Ice Python compatible with OMERO.
 ## Release
 This is a compiled Python 3 64 module.
 Most OME Python and Conda projects use Travis-CI for builds and releases, however it has limited support for Windows.
-For full cross-platform support (Linux-64, OSX-64, Win-64) Azure Pipelines is used for building and releasing packages for platforms .
+For full cross-platform support (Linux-64, OSX-64, Win-64) Azure Pipelines is used for building and releasing packages for platforms.
 
 Setup:
 - Create a new [Azure devops project](https://azure.microsoft.com/en-gb/services/devops/pipelines/)

--- a/README.md
+++ b/README.md
@@ -2,3 +2,15 @@
 [![Anaconda-Server Badge](https://anaconda.org/ome/zeroc-ice36-python/badges/version.svg)](https://anaconda.org/ome/zeroc-ice36-python)
 
 A Conda package for Zeroc Ice Python compatible with OMERO.
+
+
+## Release
+This is a compiled Python 3 64 module.
+Most OME Python and Conda projects use Travis-CI for builds and releases, however it has limited support for Windows.
+For full cross-platform support (Linux-64, OSX-64, Win-64) Azure Pipelines is used for building and releasing packages for platforms .
+
+Setup:
+- Create a new [Azure devops project](https://azure.microsoft.com/en-gb/services/devops/pipelines/)
+- Add this repository
+- Create a [secret variable](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#secret-variables) `ANACONDA_API_TOKEN`
+- [Adjust your notifications](https://docs.microsoft.com/en-us/azure/devops/notifications/manage-your-personal-notifications?view=azure-devops&tabs=preview-page) if necessary

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,76 +1,118 @@
 # Based on
 # https://github.com/MicrosoftDocs/pipelines-anaconda/blob/3cf8252785ea2c873cc9c20e676b14f7b48f35ce/azure-pipelines.yml
 
-jobs:
-- job:
-  displayName: ubuntu-16.04
-  pool:
-    vmImage: 'ubuntu-16.04'
-  strategy:
-    matrix:
-      Python36:
-        python.version: '3.6'
+trigger:
+  branches:
+    include:
+    - '*'
+  tags:
+    include:
+    - '*'
 
-  steps:
-  - bash: echo "##vso[task.prependpath]$CONDA/bin"
-    displayName: Add conda to PATH
+stages:
+- stage: conda_build
+  jobs:
+  - job:
+    displayName: ubuntu-16.04
+    pool:
+      vmImage: 'ubuntu-16.04'
+    strategy:
+      matrix:
+        Python36:
+          python.version: '3.6'
 
-  - bash: conda install -y conda-build anaconda-client
-    displayName: Create Anaconda environment
+    steps:
+    - bash: echo "##vso[task.prependpath]$CONDA/bin"
+      displayName: Add conda to PATH
 
-  - bash: |
-      conda info -a
-      conda build --python $PYTHON_VERSION .
-    displayName: build
+    - bash: conda install -y conda-build anaconda-client
+      displayName: Create Anaconda environment
 
-- job:
-  displayName: macOS-10.14
-  pool:
-    vmImage: 'macOS-10.14'
-  strategy:
-    matrix:
-      Python36:
-        python.version: '3.6'
+    - bash: |
+        conda info -a
+        conda build --python $PYTHON_VERSION .
+      displayName: build
 
-  steps:
-  - bash: echo "##vso[task.prependpath]$CONDA/bin"
-    displayName: Add conda to PATH
+    - publish: /usr/share/miniconda/conda-bld/linux-64
+      artifact: linux-64
 
-  - bash: |
-      sudo mkdir -p /opt
-      pushd /opt
-      curl -L https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/MacOSX10.13.sdk.tar.xz | sudo tar xf -
-      popd
-    displayName: Download 10.13 SDK
+  - job:
+    displayName: macOS-10.14
+    pool:
+      vmImage: 'macOS-10.14'
+    strategy:
+      matrix:
+        Python36:
+          python.version: '3.6'
 
-  # Can't write to base environment on macOS
-  - bash: conda create -n omerobuild -y conda-build anaconda-client
-    displayName: Create Anaconda environment
+    steps:
+    - bash: echo "##vso[task.prependpath]$CONDA/bin"
+      displayName: Add conda to PATH
 
-  - bash: |
-      source activate omerobuild
-      conda info -a
-      conda build --python $PYTHON_VERSION .
-    displayName: build
+    - bash: |
+        sudo mkdir -p /opt
+        pushd /opt
+        curl -L https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/MacOSX10.13.sdk.tar.xz | sudo tar xf -
+        popd
+      displayName: Download 10.13 SDK
 
-- job:
-  displayName: vs2017-win2016
-  pool:
-    vmImage: 'vs2017-win2016'
-  strategy:
-    matrix:
-      Python36:
-        python.version: '3.6'
+    # Can't write to base environment on macOS
+    - bash: conda create -n omerobuild -y conda-build anaconda-client
+      displayName: Create Anaconda environment
 
-  steps:
-  - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
-    displayName: Add conda to PATH
+    - bash: |
+        source activate omerobuild
+        conda info -a
+        conda build --python $PYTHON_VERSION .
+      displayName: build
 
-  - script: conda install -y conda-build anaconda-client
-    displayName: Create Anaconda environment
+    - publish: /Users/runner/.conda/envs/omerobuild/conda-bld/osx-64
+      artifact: osx-64
 
-  - script: |
-      call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-      conda info -a
-      conda build --python %PYTHON_VERSION% .
-    displayName: build
+  - job:
+    displayName: vs2017-win2016
+    pool:
+      vmImage: 'vs2017-win2016'
+    strategy:
+      matrix:
+        Python36:
+          python.version: '3.6'
+
+    steps:
+    - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
+      displayName: Add conda to PATH
+
+    - script: conda install -y conda-build anaconda-client
+      displayName: Create Anaconda environment
+
+    - script: |
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        conda info -a
+        conda build --python %PYTHON_VERSION% .
+      displayName: build
+
+    - publish: C:\Miniconda\conda-bld\win-64
+      artifact: win-64
+
+- stage: conda_upload
+  jobs:
+  - deployment: anaconda_cloud_upload
+    displayName: Anaconda Cloud upload
+    pool:
+      vmImage: 'Ubuntu-16.04'
+    # creates an environment if it doesn't exist
+    environment: 'conda'
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+          - bash: echo "##vso[task.prependpath]$CONDA/bin"
+            displayName: Add conda to PATH
+
+          - bash: conda install -y anaconda-client
+            displayName: Create Anaconda environment
+
+          - bash: |
+              env
+              ls -Rl $(Pipeline.Workspace)
+            displayName: List artifacts

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@ variables:
   PACKAGE_NAME: zeroc-ice36-python
   # Set this to non-empty for testing
   # This will add .test to the version and also add a testing label
-  VERSION_SUFFIX: .test
+  # VERSION_SUFFIX: .test
   # ANACONDA_USER: Dynmically set from another variable in stage conda_upload
   # ANACONDA_API_TOKEN: must be a secret variable
 
@@ -121,7 +121,7 @@ stages:
     # creates an environment if it doesn't exist
     environment: 'conda'
     # Deploy Tags only (comment out if you want to test with a branch)
-    # condition: startsWith(variables['build.sourceBranch'], 'refs/tags/')
+    condition: startsWith(variables['build.sourceBranch'], 'refs/tags/')
     strategy:
       runOnce:
         deploy:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,6 +28,8 @@ stages:
       matrix:
         Python36:
           python.version: '3.6'
+        Python37:
+          python.version: '3.7'
 
     steps:
     - bash: echo "##vso[task.prependpath]$CONDA/bin"
@@ -42,7 +44,7 @@ stages:
       displayName: build
 
     - publish: /usr/share/miniconda/conda-bld/linux-64
-      artifact: linux-64
+      artifact: linux-64-$(python.version)
 
   - job:
     displayName: macOS-10.14
@@ -52,6 +54,8 @@ stages:
       matrix:
         Python36:
           python.version: '3.6'
+        Python37:
+          python.version: '3.7'
 
     steps:
     - bash: echo "##vso[task.prependpath]$CONDA/bin"
@@ -79,7 +83,7 @@ stages:
       displayName: build
 
     - publish: /Users/runner/.conda/envs/omerobuild/conda-bld/osx-64
-      artifact: osx-64
+      artifact: osx-64-$(python.version)
 
   - job:
     displayName: vs2017-win2016
@@ -89,6 +93,8 @@ stages:
       matrix:
         Python36:
           python.version: '3.6'
+        Python37:
+          python.version: '3.7'
 
     steps:
     - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
@@ -104,7 +110,7 @@ stages:
       displayName: build
 
     - publish: C:\Miniconda\conda-bld\win-64
-      artifact: win-64
+      artifact: win-64-$(python.version)
 
 - stage: conda_upload
   jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,76 @@
+# Based on
+# https://github.com/MicrosoftDocs/pipelines-anaconda/blob/3cf8252785ea2c873cc9c20e676b14f7b48f35ce/azure-pipelines.yml
+
+jobs:
+- job:
+  displayName: ubuntu-16.04
+  pool:
+    vmImage: 'ubuntu-16.04'
+  strategy:
+    matrix:
+      Python36:
+        python.version: '3.6'
+
+  steps:
+  - bash: echo "##vso[task.prependpath]$CONDA/bin"
+    displayName: Add conda to PATH
+
+  - bash: conda install -y conda-build anaconda-client
+    displayName: Create Anaconda environment
+
+  - bash: |
+      conda info -a
+      conda build --python $PYTHON_VERSION .
+    displayName: build
+
+- job:
+  displayName: macOS-10.14
+  pool:
+    vmImage: 'macOS-10.14'
+  strategy:
+    matrix:
+      Python36:
+        python.version: '3.6'
+
+  steps:
+  - bash: echo "##vso[task.prependpath]$CONDA/bin"
+    displayName: Add conda to PATH
+
+  - bash: |
+      sudo mkdir -p /opt
+      pushd /opt
+      curl -L https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/MacOSX10.13.sdk.tar.xz | sudo tar xf -
+      popd
+    displayName: Download 10.13 SDK
+
+  # Can't write to base environment on macOS
+  - bash: conda create -n omerobuild -y conda-build anaconda-client
+    displayName: Create Anaconda environment
+
+  - bash: |
+      source activate omerobuild
+      conda info -a
+      conda build --python $PYTHON_VERSION .
+    displayName: build
+
+- job:
+  displayName: vs2017-win2016
+  pool:
+    vmImage: 'vs2017-win2016'
+  strategy:
+    matrix:
+      Python36:
+        python.version: '3.6'
+
+  steps:
+  - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
+    displayName: Add conda to PATH
+
+  - script: conda install -y conda-build anaconda-client
+    displayName: Create Anaconda environment
+
+  - script: |
+      call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+      conda info -a
+      conda build --python %PYTHON_VERSION% .
+    displayName: build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,14 @@
 # Based on
 # https://github.com/MicrosoftDocs/pipelines-anaconda/blob/3cf8252785ea2c873cc9c20e676b14f7b48f35ce/azure-pipelines.yml
 
+variables:
+  PACKAGE_NAME: zeroc-ice36-python
+  # Set this to non-empty for testing
+  # This will add .test to the version and also add a testing label
+  VERSION_SUFFIX: .test
+  # ANACONDA_USER: Dynmically set from another variable in stage conda_upload
+  # ANACONDA_API_TOKEN: must be a secret variable
+
 trigger:
   branches:
     include:
@@ -49,6 +57,10 @@ stages:
     - bash: echo "##vso[task.prependpath]$CONDA/bin"
       displayName: Add conda to PATH
 
+    # xcode image is missing headers
+    # https://github.com/travis-ci/travis-ci/issues/9640
+    # https://docs.conda.io/projects/conda-build/en/latest/resources/compiler-tools.html#macos-sdk
+    # Anaconda uses 1.9 but Ice 3.6.5 includes TLS 1.3 support which requires a more recent SecureTransport
     - bash: |
         sudo mkdir -p /opt
         pushd /opt
@@ -102,6 +114,8 @@ stages:
       vmImage: 'Ubuntu-16.04'
     # creates an environment if it doesn't exist
     environment: 'conda'
+    # Deploy Tags only (comment out if you want to test with a branch)
+    # condition: startsWith(variables['build.sourceBranch'], 'refs/tags/')
     strategy:
       runOnce:
         deploy:
@@ -116,3 +130,21 @@ stages:
               env
               ls -Rl $(Pipeline.Workspace)
             displayName: List artifacts
+
+          - bash: |
+              ANACONDA_USER=${BUILD_REPOSITORY_NAME%/*}
+              if [ -z "$ANACONDA_API_TOKEN" ]; then
+                echo ANACONDA_API_TOKEN required
+                exit 1
+              fi
+              for f in $(Pipeline.Workspace)/*/${PACKAGE_NAME}*.tar.bz2; do
+                if [ -z "${VERSION_SUFFIX}" ]; then
+                  anaconda upload --user ${ANACONDA_USER} $f
+                else
+                  anaconda upload --user ${ANACONDA_USER} $f --force -l testing
+                fi
+              done
+            env:
+              # Secret variables must be explicitly mapped
+              ANACONDA_API_TOKEN: $(ANACONDA_API_TOKEN)
+            displayName: Upload artifacts

--- a/meta.yaml
+++ b/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 4235ffeb605bcd4e22e716577f7d61e4aa1bc82f65276bb542701a81b7933356
 
 build:
-  number: 3
+  number: 4
   entry_points:
     - slice2py=slice2py:main
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "


### PR DESCRIPTION
https://dev.azure.com/test-spli/conda-zeroc-ice36-python/_build?definitionId=3&_a=summary

Azure windows builds are, perhaps not suprisingly, more reliable than travis.

Uses Azure Pipelines for all releases including Windows. This is free for opensource projects.

Travis is still enabled since most people have it enabled so it's useful for basic checks, but the deploy step is disabled.

This will require an Azure project to be created.

Testing:
```
conda create -n aztmp -c manics -c ome omero-py
```
Will install `zeroc-ice36-python 3.6.5-4` from my repo and `omero-py` from the `ome` repo. If testing on Windows ensure you don't have another Ice already in your `PATH` or `PYTHONPATH`.

If you want to test the pipeline on your own fork without messing with tags revert the last commit https://github.com/ome/conda-zeroc-ice36-python/pull/4/commits/8ed297b3d531de725c6f570057d6ff8443163d86