### PR TITLE
Windows take 2

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,7 @@ trigger:
     - '*'
 
 stages:
+
 - stage: conda_build
   jobs:
   - job:
@@ -72,17 +73,19 @@ stages:
         popd
       displayName: Download 10.13 SDK
 
-    # Can't write to base environment on macOS
-    - bash: conda create -n omerobuild -y conda-build anaconda-client
+    # Make writeable by non root
+    - bash: sudo chown -R "$USER" /usr/local/miniconda
+      displayName: Make miniconda directory writeable
+
+    - bash: conda install -y conda-build anaconda-client
       displayName: Create Anaconda environment
 
     - bash: |
-        source activate omerobuild
         conda info -a
         conda build --python $PYTHON_VERSION .
       displayName: build
 
-    - publish: /Users/runner/.conda/envs/omerobuild/conda-bld/osx-64
+    - publish: /usr/local/miniconda/conda-bld/osx-64
       artifact: osx-64-$(python.version)
 
   - job:
@@ -133,16 +136,17 @@ stages:
             displayName: Create Anaconda environment
 
           - bash: |
-              env
               ls -Rl $(Pipeline.Workspace)
             displayName: List artifacts
 
           - bash: |
+              set -ex
               ANACONDA_USER=${BUILD_REPOSITORY_NAME%/*}
               if [ -z "$ANACONDA_API_TOKEN" ]; then
                 echo ANACONDA_API_TOKEN required
                 exit 1
               fi
+              anaconda -v whoami
               for f in $(Pipeline.Workspace)/*/${PACKAGE_NAME}*.tar.bz2; do
                 if [ -z "${VERSION_SUFFIX}" ]; then
                   anaconda upload --user ${ANACONDA_USER} $f

--- a/meta.yaml
+++ b/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 4235ffeb605bcd4e22e716577f7d61e4aa1bc82f65276bb542701a81b7933356
 
 build:
-  number: 4
+  number: 5
   entry_points:
     - slice2py=slice2py:main
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "


### PR DESCRIPTION
We finally have some Windows test builds https://github.com/manics/conda-zeroc-ice36-python/pull/new/windows-take-2
Install with `conda install -c ome -c ome/label/testing omero-py`

Merge this, tag as `3.6.5-5`, and we should have a release build